### PR TITLE
Add performance improvement report and optimization roadmap

### DIFF
--- a/PERFORMANCE_REPORT.md
+++ b/PERFORMANCE_REPORT.md
@@ -2,7 +2,16 @@
 
 ## Scope and framing
 
-This report is based on a code review of the simulation/render pipeline, with an emphasis on frame-time stability for long-running fullscreen sessions. The current architecture is strong (simulation/render separation, spatial bucketing, cProfile path already present), so most upside now is in **render-cost control**, **high-population pairwise operations**, and **data-oriented hot-loop execution**.
+This report reviews the current simulation/render pipeline with a focus on frame-time stability for long-running fullscreen sessions. The architecture is already good (simulation/render separation, spatial bucketing, built-in profiling mode), so the biggest upside now is in **render-cost governance**, **pairwise workload capping**, **hot-loop acceleration**, and a **phased path to GPU/alternative-language execution where it makes sense**.
+
+---
+
+## Executive summary
+
+- **Do not rewrite immediately.** There is still large ROI available inside the current architecture.
+- **Top 3 near-term wins:** adaptive quality governor, pairwise line-budget/culling, and decoupled sim/render cadence.
+- **GPU is absolutely possible** and likely valuable for links/trails/particles first.
+- **Alternative language reimplementation is viable**, but should be scoped to hotspots first (simulation kernels or renderer path), not a big-bang rewrite.
 
 ---
 
@@ -10,218 +19,324 @@ This report is based on a code review of the simulation/render pipeline, with an
 
 ### 1) Add an adaptive quality governor (frame-budget aware)
 
-**Why this is likely #1:** The renderer performs many optional effects every frame (ambient, zone atmospherics, territory shimmer, kin/flock links, trails, particles, HUD/overlay), and boids/line effects can spike cost nonlinearly at population peaks.
+**Why this is likely #1:** renderer work is composited from many optional effects each frame, and dense boids/line scenes can spike nonlinearly.
 
-**Observed in code:**
-- Renderer tracks detailed per-stage timing (`events_ms`, `ambient_ms`, `links_ms`, `trails_ms`, `creatures_ms`, etc.), so the telemetry needed for adaptation already exists.
-- Target FPS is fixed via `clock.tick(target_fps)`.
+**Observed in codebase behavior:**
+- Stage-level timing is already tracked.
+- Target FPS is enforced, but quality does not currently adapt to budget misses.
 
-**Proposal:** Define quality tiers (Ultra/High/Medium/Low) and auto-step down/up based on rolling draw+sim budget (e.g., 60 FPS target → 16.67 ms budget).
+**Proposal:** Define quality tiers (Ultra/High/Medium/Low) and auto-adjust using rolling frame-time and hysteresis.
 
-**Tier knobs to scale dynamically:**
-- Kin/flock line density (limit max pairs per lineage/flock).
-- Trail resolution (skip every Nth historical point or reduce alpha passes).
-- Territory shimmer layers/radii.
+**Tier knobs:**
+- Max kin/flock links per frame.
+- Trail sampling rate.
+- Shimmer layers/radii.
 - Ambient particle count.
-- Attack-line and death-particle counts.
-- HUD update frequency (e.g., every 2–4 frames).
+- Animation particle counts.
+- HUD refresh cadence.
 
-**Expected impact:** Smoother frame pacing with minimal perceived quality loss during stress.
-
----
-
-### 2) Reduce pairwise O(n²) rendering work with neighbor culling structures
-
-**Why:** Pair loops in line rendering are still pairwise within groups. At high lineage concentration or large flocks, this can become a major spike source.
-
-**Observed in code:**
-- Kin lines: all-pairs within each lineage bucket with distance check.
-- Flock lines: all-pairs within each flock bucket with distance check.
-
-**Proposal options:**
-1. Spatial hash per lineage/flock (same pattern as food manager) to only compare local cells.
-2. k-nearest cap per creature (draw only nearest 3–5 links).
-3. Stochastic subsampling (stable seeded sample by lineage/flock id per frame window).
-4. Hard line budget per frame (e.g., max 2k lines) with fair rotation across groups.
-
-**Expected impact:** Major reduction of worst-case spikes in dense scenes.
+**Expected impact:** smoother frame pacing under stress with minimal visual degradation.
 
 ---
 
-### 3) Cache and incrementally update lineage statistics for territory shimmer
+### 2) Cap O(n²) pairwise line work with neighborhood culling + budgets
 
-**Why:** Territory shimmer repeatedly computes centroid/spread from full member lists each frame; this is expensive and scales with population.
+**Why:** kin/flock links are pairwise within groups and can dominate worst-case frames.
 
-**Observed in code:**
-- Each frame builds `lineage_creatures` buckets.
-- Then computes `xs`, `ys`, sums, and std-dev-like calculations for top lineages.
+**Proposal options (can combine):**
+1. Spatial hash per lineage/flock.
+2. k-nearest links per creature.
+3. Deterministic stochastic sampling per group.
+4. Global line budget per frame with round-robin fairness.
 
-**Proposal:** Maintain rolling lineage accumulators in simulation state:
-- count, sum_x, sum_y, sum_x2, sum_y2 (and optionally wrapped-space handling).
-- update on births/deaths/moves or at lower frequency (e.g., every 6 frames).
-
-**Expected impact:** Lower constant factors on every frame; better scalability.
+**Expected impact:** large p95/p99 frame-time improvements in dense clusters.
 
 ---
 
-### 4) Decouple simulation tick and render tick (fixed-step sim, variable render)
+### 3) Incremental lineage statistics for territory shimmer
 
-**Why:** Right now one simulation step is coupled to each rendered frame. When rendering is overloaded, sim cadence also slows, distorting ecosystem dynamics.
+**Why:** rebuilding lineage buckets + full spread math every frame scales poorly with population.
 
-**Proposal:**
-- Fixed simulation timestep (e.g., 30 or 60 Hz) with accumulator.
-- Render at display rate, interpolating visuals where useful.
-- Under stress: drop render quality first, avoid changing sim correctness.
+**Proposal:** maintain rolling lineage accumulators (`count/sum/sum_sq`) and refresh full recompute at reduced cadence.
 
-**Expected impact:** Better deterministic behavior and more graceful degradation.
+**Expected impact:** reduced per-frame CPU overhead and steadier frame-time.
 
 ---
 
-### 5) Move selected hot loops to native speed paths (Cython/Numba/Rust extension)
+### 4) Decouple simulation tick from render tick
 
-**Why:** Python per-object loops dominate in boids forces and pair checks.
+**Why:** render overload currently slows simulation cadence too, affecting ecosystem behavior.
 
-**Best candidates:**
-- boid neighbor-force accumulation,
-- creature update loop math,
-- pairwise link candidate generation.
+**Proposal:** fixed-step simulation (30/60 Hz) + variable-rate rendering with interpolation where needed.
 
-**Proposal:** Keep architecture, but compile narrow kernels. Start with one kernel and benchmark before/after.
+**Expected impact:** deterministic sim behavior and graceful visual degradation.
 
-**Expected impact:** Potentially very large CPU reduction without redesigning the app.
+---
+
+### 5) Accelerate hot kernels with native execution paths
+
+**Why:** Python object-loop overhead is high in boids/neighbor math.
+
+**Best first kernels:**
+- boid force accumulation,
+- motion update math,
+- link candidate generation.
+
+**Paths:** Cython / Numba / Rust extension.
+
+**Expected impact:** significant CPU reduction without total rewrite.
 
 ---
 
 ## Medium-impact improvements
 
-### 6) Data-oriented representation for simulation state
+### 6) Data-oriented simulation storage
 
-Transition from object-heavy `Creature` iteration to SoA-like arrays for hot fields (`x,y,vx,vy,energy,age,...`) while retaining dataclass facade where needed. This improves cache behavior and unlocks vectorization paths.
+Migrate hot fields to SoA buffers while preserving current API shape where practical.
 
-### 7) Multi-process split: simulation worker + render process
+### 7) Process-level split (simulation worker + renderer)
 
-Python GIL limits threaded CPU parallelism. A process split with shared memory/ring buffer snapshots can isolate simulation from render stalls and improve responsiveness.
+Avoid GIL contention and isolate simulation cadence from render stalls.
 
-### 8) Event-driven redraw shortcuts for static layers
+### 8) Recompute expensive overlays at lower cadence
 
-Zone backgrounds are already cached (good). Extend this philosophy:
-- update HUD text surfaces only when values change,
-- recalc expensive overlays at reduced cadence (e.g., every 2–3 frames) and reuse between frames.
+Cache/reuse outputs for effects that are perceptually tolerant to 15–30 Hz updates.
 
-### 9) Overdraw/alpha optimization
+### 9) Reduce alpha overdraw pressure
 
-The pipeline uses multiple full-screen alpha surfaces (`_line_surf`, `_attack_surf`, `_shimmer_surf`, theme trail surface). Consolidating passes or region-constrained draws can reduce fill-rate pressure, especially on integrated GPUs.
+Consolidate full-screen alpha passes and optionally constrain effects to dirty/active regions.
 
-### 10) Memory churn minimization
+### 10) Reduce allocation churn
 
-Several frame paths allocate transient lists/dicts (`defaultdict(list)`, per-frame bucket maps, temporary coordinate lists). Reusing pools and preallocated buffers can shave GC overhead and improve frame consistency.
+Reuse per-frame containers/buffers to minimize GC-related jitter.
 
 ---
 
-## “Out of the box” ideas
+## Out-of-the-box ideas
 
-### A) Two-mode runtime: **Eco mode** vs **Showcase mode**
+### A) Eco vs Showcase runtime modes
 
-- **Eco mode:** lower visual complexity, stable thermals/power for 24/7 screensaver use.
-- **Showcase mode:** all effects for demos.
+Automatically pick quality profile based on thermals/battery/time-of-day.
 
-Auto-select by battery state, thermal headroom, or time-of-day.
+### B) Temporal interleaving of expensive effects
 
-### B) Perceptual foveation (center-priority quality)
+Alternate heavy effects across frames to flatten frame-time spikes.
 
-If user attention is likely centered (or if preview pane is tiny), render full detail in center and reduced effects near edges. For fullscreen art this can be nearly invisible but saves cost.
+### C) Adaptive population budget tied to frame health
 
-### C) Temporal interleaving of expensive effects
+Use frame budget feedback to gently tune food/reproduction pressure.
 
-Split heavy effects across alternating frames:
-- frame N: kin/flock lines,
-- frame N+1: territory shimmer refresh,
-- frame N+2: higher-cost ambient updates.
+### D) Center-weighted quality (perceptual foveation)
 
-Perceived continuity remains high while average frame time drops.
-
-### D) Dynamic population budgeting by frame health
-
-Instead of static `max_population`, expose a soft auto-budget that nudges reproduction threshold/food spawn to keep frame time in target band.
+Keep peak quality near visual focus and degrade at periphery.
 
 ---
 
 ## Should you abandon pygame?
 
-Short answer: **not immediately**. You likely have substantial headroom left without a renderer rewrite.
+Short answer: **not yet**.
 
-### What pygame currently gives you
-- Fast iteration and portability.
-- Adequate 2D primitives for this project.
-- Existing architecture already tuned around it.
+### Why keep it for now
+- Existing codebase maturity and portability.
+- Fast iteration.
+- Enough headroom remains from algorithmic + quality-governor optimizations.
 
-### Where pygame hurts
-- CPU-bound draw loops and alpha compositing in Python-heavy paths.
-- Limited GPU pipeline leverage compared with modern GL/Vulkan-first frameworks.
+### Where pygame is limiting
+- Python-heavy draw loops.
+- CPU-side alpha compositing overhead.
+- Limited modern GPU pipeline ergonomics compared to GL/Vulkan-first stacks.
 
-### Better alternatives (if you do decide to migrate)
+### Practical decision rule
 
-1. **Moderngl / pyglet / vispy (GPU-first 2D/instanced rendering)**
-   - Best when you want to keep Python but offload draw/transform work to GPU.
-   - Biggest upside for trails, particles, links, glyph instances.
-
-2. **Godot (GDExtension/Python bridge optional)**
-   - Strong rendering pipeline, tooling, and batching.
-   - Heavier migration and ecosystem shift.
-
-3. **Rust/C++ simulation core + Python or engine front-end**
-   - Maximum long-term performance and determinism.
-   - Highest complexity cost.
-
-4. **“Nothing” (headless simulation + occasional frame emit)**
-   - If this were analytics-first, headless makes sense.
-   - For a visual screensaver product, removing realtime rendering undermines core value.
-
-### Recommended migration strategy
-
-- **Phase 1 (stay on pygame):** implement adaptive quality + pairwise culling + cadence decoupling.
-- **Phase 2:** prototype one GPU-backed renderer path for just links/trails.
-- **Phase 3:** decide based on measured gains whether full migration is justified.
-
-This de-risks effort and avoids “rewrite first, benchmark later.”
+Move off pygame only if, **after tier/culling/kernel optimizations**, you still miss your p95 frame budget on target hardware.
 
 ---
 
-## Suggested benchmark plan (before touching architecture)
+## Re-implementing in other languages: best candidates
 
-1. Define scenarios:
-   - energy mode @ pop 150/220,
-   - boids mode @ pop 150/300,
-   - worst-case lineage concentration.
-2. Capture:
-   - p50/p95 frame time,
-   - sim_ms vs draw_ms split,
-   - max spike, dropped-frame count.
-3. A/B each optimization independently.
-4. Keep a “visual acceptability” checklist (art quality regressions are easy to miss in numeric-only tuning).
+You asked for concrete language alternatives. Below is a pragmatic shortlist.
+
+### 1) **Rust** (best all-around long-term candidate)
+
+**Why it fits:**
+- High performance + memory safety.
+- Excellent for deterministic simulation core.
+- Strong ecosystem for desktop + GPU (`wgpu`).
+
+**How to apply incrementally:**
+- Start with Rust simulation core as a Python extension (PyO3/maturin) while keeping existing renderer.
+- Or build a Rust+wgpu standalone renderer once simulation parity is proven.
+
+**Pros:** max performance potential, robust architecture.
+**Cons:** higher engineering complexity, steeper team learning curve.
+
+**Best for:** long-lived project with emphasis on correctness and sustained performance.
+
+---
+
+### 2) **C++** (highest raw performance, highest operational complexity)
+
+**Why it fits:**
+- Mature high-performance path for both simulation and rendering.
+- Easy access to SDL2/OpenGL/Vulkan ecosystems.
+
+**Pros:** top-end performance and ecosystem breadth.
+**Cons:** memory-safety risks, build/tooling complexity, slower iteration.
+
+**Best for:** teams already strong in C++ who need absolute control/perf.
+
+---
+
+### 3) **Go** (good concurrency, weaker fit for graphics-heavy workloads)
+
+**Why it may fit partially:**
+- Good for orchestrating simulation/services.
+- Simpler concurrency model.
+
+**Limitations for this project:**
+- Less natural for advanced realtime rendering compared to Rust/C++.
+
+**Best for:** backend/control-plane style components, not primary renderer choice.
+
+---
+
+### 4) **Zig** (interesting systems option, smaller ecosystem)
+
+**Why consider:**
+- Performance and explicit control.
+- Cleaner low-level ergonomics than C in many cases.
+
+**Risk:** ecosystem/tooling maturity for this exact desktop + GPU stack is smaller.
+
+**Best for:** experimental systems-focused teams.
+
+---
+
+### 5) **C# with Unity/Godot C#** (engine-first option)
+
+**Why it fits:**
+- Very strong rendering/tooling pipeline out of the box.
+- Faster delivery for visually rich effects if engine constraints are acceptable.
+
+**Trade-off:** less control over low-level determinism and runtime footprint.
+
+**Best for:** rapid visual feature development with moderate performance needs.
+
+---
+
+## Language recommendation ranking for this project
+
+1. **Rust (recommended)**: best balance of performance, safety, GPU path viability.
+2. **C++**: strong but heavier engineering burden.
+3. **C# engine path**: fastest visual tooling, less low-level control.
+4. **Go/Zig**: niche fits; not first choice for this exact workload.
+
+---
+
+## GPU feasibility: yes, and likely high ROI
+
+GPU use is not only possible; this workload is a good candidate for **partial GPU offload**.
+
+### Best GPU-first targets
+
+1. **Links (kin/flock):** large number of simple line primitives.
+2. **Trails:** additive/alpha blended geometry over time.
+3. **Particles/ambient/shimmer:** classic GPU-friendly instanced draws.
+4. **Glyph transforms:** rotation/pulse handled in shaders.
+
+### Simulation on GPU?
+
+Possible, but higher complexity:
+- Compute-shader boids can be very fast.
+- Harder to maintain/debug and integrate with current Python architecture.
+
+**Recommendation:** do rendering GPU first, simulation GPU later only if needed.
+
+### Technology options
+
+- **Python + moderngl/pyglet/vispy:** lowest migration friction for GPU rendering.
+- **Rust + wgpu:** strongest long-term architecture and portability.
+- **Engine route (Godot/Unity):** high productivity, less bespoke control.
+
+### Minimal-risk GPU adoption sequence
+
+1. Keep simulation as-is.
+2. Replace only links/trails rendering with GPU path.
+3. Benchmark p95 frame-time delta.
+4. Expand GPU scope to particles/glyph passes if ROI holds.
+
+---
+
+## Migration strategies (from least to most disruptive)
+
+### Strategy A: Stay Python, add GPU renderer path (recommended first)
+
+- Keep current sim logic.
+- Offload visual hotspots to GPU.
+- Lowest risk and fastest measurable wins.
+
+### Strategy B: Hybrid Python + Rust kernels
+
+- Move boids/neighbor kernels to Rust extension.
+- Preserve current architecture and UX.
+
+### Strategy C: Full Rust rewrite (sim + render)
+
+- Maximum long-term performance and control.
+- Highest rewrite risk and delivery time.
+
+### Strategy D: Engine migration (Godot/Unity)
+
+- Strong toolchain and visual pipeline.
+- Requires re-architecture and acceptance of engine constraints.
+
+---
+
+## Suggested benchmark plan
+
+1. Scenarios:
+   - energy mode @ population 150 and 220,
+   - boids mode @ 150 and 300,
+   - intentionally dense lineage/flock clusters.
+2. Metrics:
+   - p50/p95/p99 frame-time,
+   - sim vs draw split,
+   - spike frequency and duration,
+   - power draw/thermals for long runs.
+3. A/B method:
+   - one change at a time,
+   - 3-run median,
+   - fixed seed where possible.
+4. Acceptance:
+   - maintain visual quality thresholds,
+   - no simulation behavior regressions.
 
 ---
 
 ## 30-day execution roadmap
 
 ### Week 1
-- Add frame-budget governor design doc + runtime telemetry dashboards.
-- Implement manual quality tiers first (no auto switching yet).
+- Add quality-tier controls + instrumentation dashboard.
+- Define benchmark harness and target envelopes.
 
 ### Week 2
-- Implement kin/flock line budgets and culling.
-- Add reduced-cadence shimmer/HUD updates.
+- Implement link culling/budgeting and reduced-cadence expensive overlays.
+- Capture p95/p99 impact.
 
 ### Week 3
-- Add auto quality scaling and hysteresis.
-- Add fixed-step simulation loop option and compare behavior.
+- Prototype GPU links/trails pass (Python GPU stack).
+- Evaluate perf gains and visual parity.
 
 ### Week 4
-- Prototype one native/GPU acceleration path on a single hotspot.
-- Decide go/no-go for broader renderer migration.
+- Prototype Rust kernel for one simulation hotspot.
+- Decide next quarter path: stay hybrid vs wider migration.
 
 ---
 
 ## Final recommendation
 
-The highest ROI path is to **optimize within current pygame architecture first**, because your bottlenecks appear to be specific hot loops and effect density rather than an immediate hard limit of pygame itself. A full migration should be treated as a **measured second step** after adaptive quality and pairwise-culling wins are captured.
+1. **Immediate:** optimize current architecture (quality governor + pairwise budgets + fixed-step sim).
+2. **Near-term:** add targeted GPU rendering for links/trails/particles.
+3. **Strategic:** if still constrained, move hot simulation kernels to **Rust**; reserve full rewrite for when measured evidence justifies it.
+
+This approach gives fast wins now, preserves optionality, and avoids risky rewrites before the bottlenecks are quantified.


### PR DESCRIPTION
### Motivation
- Provide a prioritized, non-invasive plan to improve frame-time stability and CPU/GPU cost for long-running runs without changing runtime behavior or code yet.

### Description
- Add `PERFORMANCE_REPORT.md`, a one-file audit that lists high-impact optimizations (adaptive quality governor, pairwise-culling for kin/flock lines, incremental lineage statistics, decoupled sim/render timestep, and targeted native/GPU kernels), medium-impact ideas, migration guidance for `pygame` (stay and optimize first, phased GPU/prototype path later), a suggested benchmark plan, and a 30-day execution roadmap.

### Testing
- Verified the codebase still compiles by running `python -m compileall primordial`, which completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa1bad7d90832c9daf75f3361ecd0d)