### PR TITLE
fix: resolve predator contact after closing movement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,7 +201,9 @@ directly to flee max speed, and the optional low-energy taper uses
 `prey_flee_low_energy_threshold`, and `prey_flee_low_energy_min_mult`. This is
 not predator spawning, not predator rescue, not extinct-trait preservation,
 and not a direct reproduction-threshold change.
-Predator near-contact diagnostics are observational only. The current config
+Predator near-contact diagnostics are observational only.
+Predators also resolve a conservative post-move closing-strike contact check against the same pursued prey target in the same tick. This does not spawn/rescue predators, does not change reproduction thresholds or kill energy caps, and still requires normal contact distance plus same-depth overlap. Diagnostics now include post-move contact opportunities and post-move kills.
+ The current config
 keys are `predator_near_contact_diagnostic_scale` and
 `predator_sustained_chase_min_frames`. They exist to measure same-depth
 contact/flee oscillation, cross-depth near misses, sustained chase without

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,8 +202,12 @@ directly to flee max speed, and the optional low-energy taper uses
 not predator spawning, not predator rescue, not extinct-trait preservation,
 and not a direct reproduction-threshold change.
 Predator near-contact diagnostics are observational only.
-Predators also resolve a conservative post-move closing-strike contact check against the same pursued prey target in the same tick. This does not spawn/rescue predators, does not change reproduction thresholds or kill energy caps, and still requires normal contact distance plus same-depth overlap. Diagnostics now include post-move contact opportunities and post-move kills.
- The current config
+Post-move contact resolution is allowed only for the same pursued target, same
+depth, normal contact distance, and living prey, after predator movement in the
+same tick when no earlier kill already occurred.
+This timing fix must not add spawning, trait preservation, reproduction
+threshold changes, or kill-cap changes.
+The current config
 keys are `predator_near_contact_diagnostic_scale` and
 `predator_sustained_chase_min_frames`. They exist to measure same-depth
 contact/flee oscillation, cross-depth near misses, sustained chase without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
-- fix: resolve predator contact after closing movement
-  - Predator-prey now resolves an additional same-target contact check immediately after predator movement in the same tick (same-depth required), using shared kill logic and unchanged reproduction/kill-cap tuning.
-  - Added post-move contact diagnostics and report fields: opportunities, same-depth vs cross-depth, post-move kills, and percent of kills from post-move contact.
-
 # Changelog
 
 All notable changes to Primordial are documented in this file.
+
+## Unreleased
+
+- fix: resolved predator contact timing by adding a same-target post-move
+  contact resolution in predator_prey (same depth and normal contact distance
+  still required).
+- Added post-move contact diagnostics for opportunities and kills.
+- No spawning, trait-preservation, reproduction-threshold, or kill-cap changes.
 
 ## [2026-05-22] — feat: add predator ambush habitat modifiers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- fix: resolve predator contact after closing movement
+  - Predator-prey now resolves an additional same-target contact check immediately after predator movement in the same tick (same-depth required), using shared kill logic and unchanged reproduction/kill-cap tuning.
+  - Added post-move contact diagnostics and report fields: opportunities, same-depth vs cross-depth, post-move kills, and percent of kills from post-move contact.
+
 # Changelog
 
 All notable changes to Primordial are documented in this file.

--- a/README.md
+++ b/README.md
@@ -277,7 +277,9 @@ In predator_prey mode, species is determined by the `aggression` trait using hys
 
 Several mechanisms prevent permanent predator dominance: the reproduction gate (recent kills required), the 60% dominance penalty (+20% reproduction threshold), prey scarcity costs, predator interference, and cross-band misses. These create negative feedback: predator success reduces prey density, which makes predation harder, which reduces predator reproduction, which allows prey to recover.
 
-Predator-collapse diagnostics also track near-contact "dance" behavior: same-depth close passes without kills, cross-depth near misses, sustained same-target chases, and whether successful kills skew toward old or low-energy prey. These diagnostics are observational only; they do not change kill distance or add a lunge/strike mechanic.
+Predator-collapse diagnostics also track near-contact "dance" behavior:
+Predators also resolve a conservative post-move closing-strike contact check against the same pursued prey target in the same tick. This does not spawn/rescue predators, does not change reproduction thresholds or kill energy caps, and still requires normal contact distance plus same-depth overlap. Diagnostics now include post-move contact opportunities and post-move kills.
+ same-depth close passes without kills, cross-depth near misses, sustained same-target chases, and whether successful kills skew toward old or low-energy prey. These diagnostics are observational only; they do not change kill distance or add a lunge/strike mechanic.
 
 For the full predator-prey ecology explanation, see [docs/organism_biology.md](docs/organism_biology.md) and [docs/predator_prey_system_guide.md](docs/predator_prey_system_guide.md).
 

--- a/README.md
+++ b/README.md
@@ -277,9 +277,18 @@ In predator_prey mode, species is determined by the `aggression` trait using hys
 
 Several mechanisms prevent permanent predator dominance: the reproduction gate (recent kills required), the 60% dominance penalty (+20% reproduction threshold), prey scarcity costs, predator interference, and cross-band misses. These create negative feedback: predator success reduces prey density, which makes predation harder, which reduces predator reproduction, which allows prey to recover.
 
-Predator-collapse diagnostics also track near-contact "dance" behavior:
-Predators also resolve a conservative post-move closing-strike contact check against the same pursued prey target in the same tick. This does not spawn/rescue predators, does not change reproduction thresholds or kill energy caps, and still requires normal contact distance plus same-depth overlap. Diagnostics now include post-move contact opportunities and post-move kills.
- same-depth close passes without kills, cross-depth near misses, sustained same-target chases, and whether successful kills skew toward old or low-energy prey. These diagnostics are observational only; they do not change kill distance or add a lunge/strike mechanic.
+Predator-collapse diagnostics also track near-contact "dance" behavior: same-depth
+close passes without kills, cross-depth near misses, sustained same-target
+chases, and whether successful kills skew toward old or low-energy prey. These
+diagnostics are observational only; they do not change kill distance or add a
+separate lunge/strike range bonus.
+
+Predators also use a conservative post-move contact resolution: if a predator
+was engaged with a prey target and did not already kill before movement, the
+same target is checked again immediately after predator movement. A kill still
+requires normal contact distance and same-depth overlap, and this timing fix
+does not change spawning, trait preservation, reproduction thresholds, kill
+energy caps, rarity/refuge tuning, or prey frailty tuning.
 
 For the full predator-prey ecology explanation, see [docs/organism_biology.md](docs/organism_biology.md) and [docs/predator_prey_system_guide.md](docs/predator_prey_system_guide.md).
 

--- a/docs/predator_prey_system_guide.md
+++ b/docs/predator_prey_system_guide.md
@@ -125,6 +125,8 @@ When a predator reaches contact range but the prey is in another band, that is a
 whether depth is protecting prey.
 
 Near-contact diagnostics now also record when predators repeatedly reach a
+Predators also resolve a conservative post-move closing-strike contact check against the same pursued prey target in the same tick. This does not spawn/rescue predators, does not change reproduction thresholds or kill energy caps, and still requires normal contact distance plus same-depth overlap. Diagnostics now include post-move contact opportunities and post-move kills.
+
 configurable band around contact range without converting the hunt. The
 diagnostics separate:
 

--- a/docs/predator_prey_system_guide.md
+++ b/docs/predator_prey_system_guide.md
@@ -124,9 +124,7 @@ When a predator reaches contact range but the prey is in another band, that is a
 **cross-band miss**. The HUD reports recent cross-band misses so you can tell
 whether depth is protecting prey.
 
-Near-contact diagnostics now also record when predators repeatedly reach a
-Predators also resolve a conservative post-move closing-strike contact check against the same pursued prey target in the same tick. This does not spawn/rescue predators, does not change reproduction thresholds or kill energy caps, and still requires normal contact distance plus same-depth overlap. Diagnostics now include post-move contact opportunities and post-move kills.
-
+Near-contact diagnostics also record when predators repeatedly reach a
 configurable band around contact range without converting the hunt. The
 diagnostics separate:
 
@@ -136,6 +134,13 @@ diagnostics separate:
 - sustained same-target chases that still fail to end in kills;
 - kills that land mainly on old or low-energy prey, which indicates prey
   frailty is doing work on the prey side rather than through predator rescue.
+
+Separately, predator_prey now includes a conservative post-move contact
+resolution to fix a timing asymmetry: after a predator closes movement, the
+same pursued prey target is checked again in the same tick if no kill already
+occurred. The kill still requires normal contact distance and same-depth
+overlap, and this does not change spawning, trait preservation, reproduction
+thresholds, kill energy caps, rarity/refuge tuning, or prey frailty tuning.
 
 ## Zones and Environmental Pressure
 

--- a/docs/primordial_guide.md
+++ b/docs/primordial_guide.md
@@ -844,11 +844,16 @@ Predator-prey exposes additional ecology-only tuning for this pass:
 
 The prey flee settings change only prey escape speed under age/energy frailty.
 The near-contact settings are diagnostics-only and do not change kill distance
-Predators also resolve a conservative post-move closing-strike contact check against the same pursued prey target in the same tick. This does not spawn/rescue predators, does not change reproduction thresholds or kill energy caps, and still requires normal contact distance plus same-depth overlap. Diagnostics now include post-move contact opportunities and post-move kills.
-
-or add a lunge/strike mechanic. They exist to separate same-depth contact/flee
+or add a separate lunge/strike range bonus. They exist to separate same-depth contact/flee
 oscillation, cross-depth misses, sustained chase without kill, and kills that
 skew toward old or low-energy prey.
+
+Predators also apply a conservative post-move contact check in the same tick:
+if a predator was engaged with a prey target and did not already kill before
+movement, the same target is checked again after movement. A kill still
+requires normal contact distance and same-depth overlap, and this timing fix
+does not change spawning, trait preservation, reproduction thresholds, kill
+energy caps, rarity/refuge tuning, or prey frailty tuning.
 
 Actions in the footer and Actions category use the same behavior as their
 keyboard shortcuts. Destructive reset actions require confirmation.

--- a/docs/primordial_guide.md
+++ b/docs/primordial_guide.md
@@ -844,6 +844,8 @@ Predator-prey exposes additional ecology-only tuning for this pass:
 
 The prey flee settings change only prey escape speed under age/energy frailty.
 The near-contact settings are diagnostics-only and do not change kill distance
+Predators also resolve a conservative post-move closing-strike contact check against the same pursued prey target in the same tick. This does not spawn/rescue predators, does not change reproduction thresholds or kill energy caps, and still requires normal contact distance plus same-depth overlap. Diagnostics now include post-move contact opportunities and post-move kills.
+
 or add a lunge/strike mechanic. They exist to separate same-depth contact/flee
 oscillation, cross-depth misses, sustained chase without kill, and kills that
 skew toward old or low-energy prey.

--- a/primordial/simulation/simulation.py
+++ b/primordial/simulation/simulation.py
@@ -209,6 +209,10 @@ class PredatorHuntResult:
 
     engaged: bool
     killed: bool
+    target_prey: Creature | None = None
+    target_dist_sq: float | None = None
+    contact_dist: float | None = None
+    same_depth: bool = False
     hunt_modifiers: PredatorHuntModifiers = field(default_factory=PredatorHuntModifiers)
 
 
@@ -1620,6 +1624,11 @@ class Simulation:
                         ),
                     )
                 creature.update_position(1.0, self.width, self.height)
+                self._resolve_post_move_predator_contact(
+                    creature,
+                    hunt_result=hunt_result,
+                    repro_threshold=repro_threshold,
+                )
 
                 # Broad omnivory softens the legacy predator metabolic premium.
                 predator_cost_multiplier = 1.0 + (
@@ -1880,6 +1889,8 @@ class Simulation:
             return PredatorHuntResult(
                 engaged=False,
                 killed=False,
+                target_prey=best_prey,
+                target_dist_sq=best_dist_sq,
                 hunt_modifiers=hunt_modifiers,
             )
 
@@ -1911,46 +1922,26 @@ class Simulation:
                     and predator.depth_band == best_prey.depth_band
                 ),
             )
+        same_depth = predator.depth_band == best_prey.depth_band
         if (
             best_dist_sq < (contact_dist * contact_dist)
             and best_prey.energy > 0.0
-            and predator.depth_band == best_prey.depth_band
+            and same_depth
         ):
-            # Transfer from prey to predator; prevents multiple predators
-            # farming energy from an already-dead prey in the same frame.
-            pre_kill_energy = predator.energy
-            prey_energy_before_kill = best_prey.energy
-            energy_gain = min(self._get_predator_kill_energy_gain_cap(), best_prey.energy)
-            predator.energy = min(1.0, predator.energy + energy_gain)
-            predator.recent_animal_energy = min(
-                1.0,
-                predator.recent_animal_energy + energy_gain,
-            )
-            predator.satiety_ticks_remaining = self._get_predator_satiety_ticks()
-            best_prey.energy = 0.0
-            self.predation_kill_count += 1
-            self._predation_victims_this_frame.add(id(best_prey))
-            self._recent_kill_frames.append(self._frame)
-            self._record_predator_kill(
+            self._resolve_predator_kill(
                 predator,
-                pre_kill_energy=pre_kill_energy,
-                post_kill_energy=predator.energy,
-                repro_threshold=repro_threshold,
                 prey=best_prey,
-                prey_energy_at_kill=prey_energy_before_kill,
-                refuge_modifiers=hunt_modifiers.refuge,
-                rarity_modifiers=hunt_modifiers.rarity,
+                repro_threshold=repro_threshold,
+                hunt_modifiers=hunt_modifiers,
+                post_move=False,
             )
-            self.active_attacks.append((
-                predator.x, predator.y,
-                best_prey.x, best_prey.y,
-                predator.species,
-                predator.genome.hue,
-                predator.genome.saturation,
-            ))
             return PredatorHuntResult(
                 engaged=True,
                 killed=True,
+                target_prey=best_prey,
+                target_dist_sq=best_dist_sq,
+                contact_dist=contact_dist,
+                same_depth=same_depth,
                 hunt_modifiers=hunt_modifiers,
             )
         elif best_dist_sq < (contact_dist * contact_dist) and best_prey.energy > 0.0:
@@ -1962,8 +1953,50 @@ class Simulation:
         return PredatorHuntResult(
             engaged=True,
             killed=False,
+            target_prey=best_prey,
+            target_dist_sq=best_dist_sq,
+            contact_dist=contact_dist,
+            same_depth=same_depth,
             hunt_modifiers=hunt_modifiers,
         )
+
+    def _resolve_predator_kill(
+        self,
+        predator: Creature,
+        *,
+        prey: Creature,
+        repro_threshold: float,
+        hunt_modifiers: PredatorHuntModifiers,
+        post_move: bool,
+    ) -> None:
+        pre_kill_energy = predator.energy
+        prey_energy_before_kill = prey.energy
+        energy_gain = min(self._get_predator_kill_energy_gain_cap(), prey.energy)
+        predator.energy = min(1.0, predator.energy + energy_gain)
+        predator.recent_animal_energy = min(1.0, predator.recent_animal_energy + energy_gain)
+        predator.satiety_ticks_remaining = self._get_predator_satiety_ticks()
+        prey.energy = 0.0
+        self.predation_kill_count += 1
+        self._predation_victims_this_frame.add(id(prey))
+        self._recent_kill_frames.append(self._frame)
+        self._record_predator_kill(
+            predator,
+            pre_kill_energy=pre_kill_energy,
+            post_kill_energy=predator.energy,
+            repro_threshold=repro_threshold,
+            prey=prey,
+            prey_energy_at_kill=prey_energy_before_kill,
+            refuge_modifiers=hunt_modifiers.refuge,
+            rarity_modifiers=hunt_modifiers.rarity,
+            post_move=post_move,
+        )
+        self.active_attacks.append((
+            predator.x, predator.y,
+            prey.x, prey.y,
+            predator.species,
+            predator.genome.hue,
+            predator.genome.saturation,
+        ))
 
     def _prey_flee(self, prey: Creature, bucket: dict) -> bool:
         """Prey flees from nearest predator within a tuned sensing range.
@@ -3865,6 +3898,46 @@ class Simulation:
             return True
         return False
 
+    def _resolve_post_move_predator_contact(
+        self,
+        predator: Creature,
+        *,
+        hunt_result: PredatorHuntResult,
+        repro_threshold: float,
+    ) -> None:
+        if not hunt_result.engaged or hunt_result.killed:
+            return
+        prey = hunt_result.target_prey
+        if predator.energy <= 0.0 or prey is None or prey.energy <= 0.0:
+            return
+        contact_dist = hunt_result.contact_dist
+        if contact_dist is None:
+            return
+        dist_sq = self._distance_sq(predator.x, predator.y, prey.x, prey.y)
+        if hunt_result.target_dist_sq is not None and hunt_result.target_dist_sq <= (contact_dist * contact_dist):
+            return
+        life = self._predator_diag_active.get(id(predator))
+        if life is not None:
+            life["post_move_contact_opportunities"] += 1
+        if dist_sq > (contact_dist * contact_dist):
+            return
+        same_depth = predator.depth_band == prey.depth_band
+        if life is not None:
+            life["near_contact_after_move_frames"] += 1
+            if same_depth:
+                life["post_move_contact_same_depth_opportunities"] += 1
+            else:
+                life["post_move_contact_cross_depth_opportunities"] += 1
+        if not same_depth:
+            return
+        self._resolve_predator_kill(
+            predator,
+            prey=prey,
+            repro_threshold=repro_threshold,
+            hunt_modifiers=hunt_result.hunt_modifiers,
+            post_move=True,
+        )
+
     def _sweep_frame_deaths(
         self,
         dead_creatures: list[Creature],
@@ -5126,6 +5199,8 @@ class Simulation:
             "cross_band_misses_inside_refuge": 0,
             "cross_band_misses_outside_refuge": 0,
             "near_contact_frames": 0,
+            "near_contact_before_move_frames": 0,
+            "near_contact_after_move_frames": 0,
             "near_contact_no_kill_frames": 0,
             "near_contact_same_depth_no_kill_frames": 0,
             "near_contact_cross_depth_no_kill_frames": 0,
@@ -5133,6 +5208,10 @@ class Simulation:
             "near_contact_with_low_energy_prey_frames": 0,
             "near_contact_no_kill_with_old_prey_frames": 0,
             "near_contact_no_kill_with_low_energy_prey_frames": 0,
+            "post_move_contact_kills": 0,
+            "post_move_contact_opportunities": 0,
+            "post_move_contact_same_depth_opportunities": 0,
+            "post_move_contact_cross_depth_opportunities": 0,
             "sustained_chase_frames": 0,
             "max_sustained_chase_frames": 0,
             "kills_after_sustained_chase": 0,
@@ -5263,6 +5342,7 @@ class Simulation:
         no_kill: bool,
     ) -> None:
         life = self._ensure_predator_life(predator)
+        life["near_contact_before_move_frames"] += 1
         age_fraction = prey.get_age_fraction()
         is_old = age_fraction >= _PREY_FRAILTY_OLD_AGE_FRACTION
         is_low_energy = prey.energy < self._get_prey_flee_low_energy_threshold()
@@ -5307,6 +5387,7 @@ class Simulation:
         prey_energy_at_kill: float,
         refuge_modifiers: PredatorRefugeModifiers,
         rarity_modifiers: PredatorRarityModifiers,
+        post_move: bool = False,
     ) -> None:
         life = self._ensure_predator_life(predator)
         life["kills"] += 1
@@ -5337,6 +5418,8 @@ class Simulation:
             life["peak_reached_threshold"] = True
         if rarity_modifiers.active:
             life["kills_while_rarity_active"] += 1
+        if post_move:
+            life["post_move_contact_kills"] += 1
 
     def _record_predator_post_cost_state(
         self,

--- a/tests/test_ecology_sensing.py
+++ b/tests/test_ecology_sensing.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 from primordial.settings import Settings
 from primordial.simulation import Simulation
+from primordial.simulation.simulation import PredatorHuntResult
 from primordial.simulation.creature import Creature
 from primordial.simulation.genome import Genome
 from primordial.simulation.zones import Zone
@@ -480,6 +481,44 @@ class EcologySensingTests(unittest.TestCase):
         self.assertIn("near_contact_no_kill_frames", life)
         self.assertIn("max_sustained_chase_frames", life)
         self.assertIn("killed_prey_condition_buckets", life)
+        self.assertIn("post_move_contact_kills", life)
+        self.assertIn("post_move_contact_opportunities", life)
+
+    def test_post_move_contact_kill_resolves_after_predator_movement(self) -> None:
+        simulation = self._build_simulation("predator_prey")
+        simulation.settings.epistasis_enabled = False
+        predator = Creature(x=100.0, y=100.0, genome=Genome(size=0.6, speed=1.0, aggression=0.9), energy=0.2, lineage_id=1, species="predator")
+        prey = Creature(x=114.0, y=100.0, genome=Genome(size=0.2, speed=0.1, aggression=0.1), energy=0.4, lineage_id=2, species="prey")
+        predator.depth_band = prey.depth_band = 1
+        simulation.creatures = [predator, prey]
+        contact_dist = (predator.get_radius() + prey.get_radius()) * simulation._get_predator_contact_kill_distance_scale()
+        result = PredatorHuntResult(
+            engaged=True,
+            killed=False,
+            target_prey=prey,
+            target_dist_sq=(contact_dist + 0.3) ** 2,
+            contact_dist=contact_dist,
+            same_depth=True,
+        )
+        predator.x = prey.x - (contact_dist - 0.1)
+        simulation._resolve_post_move_predator_contact(
+            predator, hunt_result=result, repro_threshold=simulation._get_reproduction_threshold(predator)
+        )
+        self.assertEqual(prey.energy, 0.0)
+        life = simulation.export_predator_diagnostics()["active_lives"][0]
+        self.assertEqual(life["post_move_contact_kills"], 1)
+
+    def test_post_move_contact_does_not_kill_when_cross_depth(self) -> None:
+        simulation = self._build_simulation("predator_prey")
+        simulation.settings.epistasis_enabled = False
+        predator = Creature(x=100.0, y=100.0, genome=Genome(size=0.6, speed=1.0, aggression=0.9), energy=0.2, lineage_id=1, species="predator")
+        prey = Creature(x=114.8, y=100.0, genome=Genome(size=0.2, speed=0.1, aggression=0.1), energy=0.4, lineage_id=2, species="prey")
+        predator.depth_band = 1
+        prey.depth_band = 2
+        simulation.creatures = [predator, prey]
+        with patch("random.gauss", return_value=0.0), patch.object(simulation, "_update_predator_prey_depth_band", return_value=None):
+            simulation._step_predator_prey()
+        self.assertGreater(prey.energy, 0.0)
 
     def test_same_depth_near_contact_no_kill_increments(self) -> None:
         simulation = self._build_simulation("predator_prey")

--- a/tests/test_predator_collapse_diagnostics.py
+++ b/tests/test_predator_collapse_diagnostics.py
@@ -66,6 +66,10 @@ def _make_life(
     near_contact_with_low_energy_prey_frames=0,
     near_contact_no_kill_with_old_prey_frames=0,
     near_contact_no_kill_with_low_energy_prey_frames=0,
+    post_move_contact_kills=0,
+    post_move_contact_opportunities=0,
+    post_move_contact_same_depth_opportunities=0,
+    post_move_contact_cross_depth_opportunities=0,
     sustained_chase_frames=0,
     max_sustained_chase_frames=0,
     kills_after_sustained_chase=0,
@@ -156,6 +160,10 @@ def _make_life(
         "near_contact_no_kill_with_low_energy_prey_frames": (
             near_contact_no_kill_with_low_energy_prey_frames
         ),
+        "post_move_contact_kills": post_move_contact_kills,
+        "post_move_contact_opportunities": post_move_contact_opportunities,
+        "post_move_contact_same_depth_opportunities": post_move_contact_same_depth_opportunities,
+        "post_move_contact_cross_depth_opportunities": post_move_contact_cross_depth_opportunities,
         "sustained_chase_frames": sustained_chase_frames,
         "max_sustained_chase_frames": max_sustained_chase_frames,
         "kills_after_sustained_chase": kills_after_sustained_chase,
@@ -459,6 +467,10 @@ class TestReportSections(unittest.TestCase):
                 near_contact_cross_depth_no_kill_frames=3,
                 near_contact_no_kill_with_old_prey_frames=4,
                 near_contact_no_kill_with_low_energy_prey_frames=5,
+                post_move_contact_opportunities=4,
+                post_move_contact_same_depth_opportunities=3,
+                post_move_contact_cross_depth_opportunities=1,
+                post_move_contact_kills=2,
                 max_sustained_chase_frames=24,
                 kills_after_sustained_chase=1,
                 killed_prey_age_fractions=[0.2, 0.82],
@@ -481,6 +493,10 @@ class TestReportSections(unittest.TestCase):
         self.assertEqual(result["killed_prey_age_bucket_counts"]["old"], 1)
         self.assertEqual(result["killed_prey_energy_bucket_counts"]["low_energy"], 1)
         self.assertAlmostEqual(result["average_killed_prey_energy"], 0.4)
+        self.assertEqual(result["post_move_contact_opportunities"], 4)
+        self.assertEqual(result["post_move_contact_same_depth_opportunities"], 3)
+        self.assertEqual(result["post_move_contact_cross_depth_opportunities"], 1)
+        self.assertEqual(result["post_move_contact_kills"], 2)
         self.assertAlmostEqual(
             result["pct_near_contact_no_kill_frames_with_low_energy_prey"],
             55.55555555555556,

--- a/tools/predator_collapse_diagnostics.py
+++ b/tools/predator_collapse_diagnostics.py
@@ -698,6 +698,18 @@ def _section_g_near_contact_dance(
         int(l.get("near_contact_no_kill_with_low_energy_prey_frames", 0))
         for l in all_completed
     )
+    post_move_contact_opportunities = sum(
+        int(l.get("post_move_contact_opportunities", 0)) for l in all_completed
+    )
+    post_move_contact_same_depth_opportunities = sum(
+        int(l.get("post_move_contact_same_depth_opportunities", 0)) for l in all_completed
+    )
+    post_move_contact_cross_depth_opportunities = sum(
+        int(l.get("post_move_contact_cross_depth_opportunities", 0)) for l in all_completed
+    )
+    post_move_contact_kills = sum(
+        int(l.get("post_move_contact_kills", 0)) for l in all_completed
+    )
     max_sustained_chase_frames = [
         int(l.get("max_sustained_chase_frames", 0)) for l in all_completed
     ]
@@ -790,6 +802,11 @@ def _section_g_near_contact_dance(
             near_contact_low_energy_no_kill_frames,
             total_near_contact_no_kill_frames,
         ),
+        "post_move_contact_opportunities": post_move_contact_opportunities,
+        "post_move_contact_same_depth_opportunities": post_move_contact_same_depth_opportunities,
+        "post_move_contact_cross_depth_opportunities": post_move_contact_cross_depth_opportunities,
+        "post_move_contact_kills": post_move_contact_kills,
+        "pct_kills_post_move_contact": _pct(post_move_contact_kills, total_kill_samples),
         "sustained_chase_min_frames": sustained_chase_min_frames,
     }
 
@@ -1292,6 +1309,11 @@ def render_markdown(report: dict[str, Any]) -> str:
         lines.append(f"- **Near-contact no-kill frames:** {g.get('near_contact_no_kill_frames', 0)}")
         lines.append(f"- **Same-depth near-contact no-kill frames:** {g.get('same_depth_near_contact_no_kill_frames', 0)}")
         lines.append(f"- **Cross-depth near-contact no-kill frames:** {g.get('cross_depth_near_contact_no_kill_frames', 0)}")
+        lines.append(f"- **Post-move contact opportunities:** {g.get('post_move_contact_opportunities', 0)}")
+        lines.append(f"- **Post-move same-depth opportunities:** {g.get('post_move_contact_same_depth_opportunities', 0)}")
+        lines.append(f"- **Post-move cross-depth misses:** {g.get('post_move_contact_cross_depth_opportunities', 0)}")
+        lines.append(f"- **Post-move contact kills:** {g.get('post_move_contact_kills', 0)}")
+        lines.append(f"- **% total kills from post-move contact:** {_pct_fmt(g.get('pct_kills_post_move_contact'))}")
         lines.append(f"- **Near-contact frames / completed life:** {_fmt(g.get('near_contact_frames_per_completed_life'))}")
         lines.append(f"- **% lives with near-contact no-kill frames:** {_pct_fmt(g.get('pct_lives_with_near_contact_no_kill_frames'))}")
         lines.append(f"- **Median max sustained chase frames:** {_fmt(g.get('median_max_sustained_chase_frames'))}")


### PR DESCRIPTION
### Motivation
- Predators were frequently getting visually within kill range after moving but failed to convert the hunt because contact was only checked before movement, producing near-contact “dance” failures.  
- The goal is a conservative same-tick post-move contact resolution to let a committed closing move convert to a kill when appropriate while preserving existing ecological tuning and invariants.  
- Changes must be runtime-only (no persistence of object ids) and must not alter spawning, reproduction thresholds, kill caps, rarity/refuge tuning, or prey frailty tuning.

### Description
- Extended `PredatorHuntResult` with runtime-only fields (`target_prey`, `target_dist_sq`, `contact_dist`, `same_depth`) so the pursued target/context is available after the predator’s move.  
- Added a shared helper `_resolve_predator_kill()` that factors the kill-transfer and diagnostics logic, and updated the pre-move kill path to call it to avoid duplication.  
- Added `_resolve_post_move_predator_contact()` and invoke it immediately after `creature.update_position()` in the predator loop to perform a conservative post-move same-target contact check and resolve the kill if conditions (alive, same target, within `contact_dist`, same depth) hold.  
- Added predator-life telemetry fields and diagnostics plumbing for post-move opportunities/kills (`post_move_contact_opportunities`, `post_move_contact_same_depth_opportunities`, `post_move_contact_cross_depth_opportunities`, `post_move_contact_kills`) and updated `tools/predator_collapse_diagnostics.py` and its markdown output to report them; also updated tests and docs and CHANGELOG to describe the behavior.

### Testing
- Ran the focused unit set `python -m unittest tests.test_ecology_sensing` which passed and includes the new post-move contact unit tests.  
- Attempted full test discovery with `python -m unittest discover tests`, but it could not complete in this environment because many graphical/import-heavy tests require `pygame` which is not installed here.  
- Attempted the intended smoke diagnostic runs (`tools/predator_collapse_diagnostics.py`) but the configured `.venv/bin/python` was not present in this environment so those smoke runs were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d8b490f4832c9332e55ac0b7c3e4)