### PR TITLE
chore: clean up predator-prey docs and diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Primordial are documented in this file.
 
+## [2026-05-24] — chore: clean up predator prey docs and diagnostics
+
+- Cleaned predator-prey documentation wording for usable depth-adjusted prey sightings, finite-radius omnidirectional sensing, quarry-memory constraints, and prey frailty scope.
+- Removed awkward duplicated paragraph spacing in predator-prey guide sections after recent merges.
+- Refined predator collapse report wording for temporary predator-zero interpretation and active/failed pursuit recommendation language without changing report semantics.
+
 ## [2026-05-23] — feat: add predator quarry memory
 
 - Added conservative predator quarry memory with short-lived last-known-position pursuit in predator_prey mode.

--- a/README.md
+++ b/README.md
@@ -699,7 +699,6 @@ Use these tools when you want to understand long-run behavior, inspect lineage a
 
 Predators now choose among **final sensed usable prey targets**; a nearby prey that fails depth-adjusted sensing no longer blocks pursuit of a slightly farther usable target.
 
-
 - Predators now keep a short quarry memory (last seen prey position/depth) for conservative pursuit when live sensing briefly fails; this memory steering is weaker than live sensing and does not count as a usable prey sighting.
 
 - Quarry-memory diagnostics now separate strict target switches from same-target reacquisitions and report memory-assisted same-target kills via `kills_after_memory_chase`.

--- a/docs/help_predator_prey.md
+++ b/docs/help_predator_prey.md
@@ -13,7 +13,7 @@ Predator-prey mode also adds an abstract vertical layer called **depth bands**. 
 
 ## How Predators Behave
 
-A predator scans for the nearest prey within its sensing range. When it detects prey, it steers toward it and tries to match its depth band. Simple epistasis can bend that sensing and contact quality: large fast predators tend to handle contact better but pay more to move, while depth specialists sense best in-band and worse across bands.
+A predator scans within a finite-radius omnidirectional sensing range and pursues a final depth-adjusted usable prey target. When it has a usable target, it steers toward that prey and tries to match its depth band. Simple epistasis can bend that sensing and contact quality: large fast predators tend to handle contact better but pay more to move, while depth specialists sense best in-band and worse across bands.
 
 **Kill on contact**: when the predator and prey are close enough and in the same depth band, the predator kills the prey. Kill energy gain is capped.
 
@@ -25,13 +25,15 @@ A predator scans for the nearest prey within its sensing range. When it detects 
 
 **Interference**: predators near other predators suffer reduced hunting effectiveness, preventing predator swarms from wiping out local prey instantly.
 
+**Quarry memory**: predators keep short-term last-known-position memory for conservative pursuit when live sensing drops out. Memory pursuit is weaker than live sensing, does not increment usable sighting metrics, and still requires normal same-depth contact for kills.
+
 **Movement cost**: predators pay a metabolic premium on movement. When prey are scarce (below 15% of population), predators pay additional scarcity penalty energy costs.
 
 ## How Prey Behave
 
 Prey search for nearby food within their current depth band. If food is unavailable in their band, they may shift toward another band where food is present. Small fast prey, asymmetric darters, and appendage-rich bodies can gain modest fleeing advantages, while specialized depth morphs tend to read their home band better than other bands.
 
-**Fleeing**: when a prey senses a nearby predator, it steers directly away and may attempt to shift to a different depth band to escape. Fleeing takes priority over food seeking.
+**Fleeing**: when a prey senses a nearby predator, it steers directly away and may attempt to shift to a different depth band to escape. Fleeing takes priority over food seeking. Prey frailty (age and low-energy slowdown) makes compromised prey easier to catch, but it does not directly suppress prey population counts.
 
 **Cost model**: prey pay standard movement cost, longevity metabolic cost, sensing upkeep, overcrowding penalty, and zone modifiers. They do not pay the predator metabolic premium.
 

--- a/docs/predator_prey_system_guide.md
+++ b/docs/predator_prey_system_guide.md
@@ -431,8 +431,6 @@ Predator-prey mode now supports a modest, capped rarity advantage for living pre
 
 Predators now choose among final sensed usable prey targets; a nearby prey that fails depth-adjusted sensing no longer blocks pursuit of another usable target.
 
-
 Predators now keep short quarry memory (target id, last-known position/depth, last-seen frame) and can briefly pursue last known position when live sensing drops out. Memory pursuit is weaker than live sensing, does not increment usable sighting metrics, and does not bypass normal same-depth contact kill rules.
-
 
 Quarry-memory diagnostics now distinguish strict target switches from same-target reacquisitions, and `kills_after_memory_chase` reports memory-assisted same-target kills after memory chase episodes.

--- a/docs/primordial_guide.md
+++ b/docs/primordial_guide.md
@@ -1051,8 +1051,6 @@ Predator active chase speed and prey flee speed are intentionally separated: pre
 
 Predators now choose among final sensed usable prey targets; a nearby prey that fails depth-adjusted sensing no longer blocks pursuit of another usable target.
 
-
 Predators now keep short quarry memory (target id, last-known position/depth, last-seen frame) and can briefly pursue last known position when live sensing drops out. Memory pursuit is weaker than live sensing, does not increment usable sighting metrics, and does not bypass normal same-depth contact kill rules.
-
 
 Quarry-memory diagnostics now distinguish strict target switches from same-target reacquisitions, and `kills_after_memory_chase` reports memory-assisted same-target kills after memory chase episodes.

--- a/tests/test_predator_collapse_diagnostics.py
+++ b/tests/test_predator_collapse_diagnostics.py
@@ -604,7 +604,7 @@ class TestBuildAndRenderReport(unittest.TestCase):
         )
         md = render_markdown(build_report([run]))
         self.assertIn(
-            "high memory frames with zero kills-after-memory may indicate broken memory-kill instrumentation.",
+            "memory chase frames are nonzero but kills_after_memory_chase stayed zero; verify memory-kill instrumentation and chase conversion.",
             md,
         )
 
@@ -621,7 +621,7 @@ class TestBuildAndRenderReport(unittest.TestCase):
         )
         md = render_markdown(build_report([run]))
         self.assertNotIn(
-            "high memory frames with zero kills-after-memory may indicate broken memory-kill instrumentation.",
+            "memory chase frames are nonzero but kills_after_memory_chase stayed zero; verify memory-kill instrumentation and chase conversion.",
             md,
         )
         self.assertIn(
@@ -680,10 +680,10 @@ class TestBuildAndRenderReport(unittest.TestCase):
         )
         self.assertEqual(
             lines[4],
-            "## [2026-05-23] — feat: add predator quarry memory",
+            "## [2026-05-24] — chore: clean up predator prey docs and diagnostics",
         )
         self.assertEqual(
-            changelog.count("## [2026-05-23] — feat: add predator quarry memory"),
+            changelog.count("## [2026-05-24] — chore: clean up predator prey docs and diagnostics"),
             1,
         )
 

--- a/tools/predator_collapse_diagnostics.py
+++ b/tools/predator_collapse_diagnostics.py
@@ -947,14 +947,14 @@ def _section_k_recommendations(
 
     if long_scarcity_pct > 40:
         recommendations.append(
-            f"LONG SCARCITY dominates ({long_scarcity_pct:.0f}% of deaths): "
+            f"LONG SCARCITY is common ({long_scarcity_pct:.0f}% of deaths): "
             "Predator rarity advantage or predator refuge likely helps. "
             "Predators are not finding prey often enough."
         )
 
     if active_hunting_pct + after_failed_pursuit_pct > 40:
         recommendations.append(
-            f"ACTIVE/FAILED PURSUIT dominates ({active_hunting_pct:.0f}% active, "
+            f"ACTIVE/FAILED PURSUIT is common ({active_hunting_pct:.0f}% active, "
             f"{after_failed_pursuit_pct:.0f}% failed pursuit): "
             "Contact/sense/depth tuning or refuges likely help. "
             "Predators see prey but cannot convert."
@@ -1375,7 +1375,7 @@ def render_markdown(report: dict[str, Any]) -> str:
         memory_chase_frames = int(g.get("memory_chase_frames", 0))
         kills_after_memory_chase = int(g.get("kills_after_memory_chase", 0))
         if memory_chase_frames > 0 and kills_after_memory_chase == 0:
-            lines.append("- **Interpretation:** high memory frames with zero kills-after-memory may indicate broken memory-kill instrumentation.")
+            lines.append("- **Interpretation:** memory chase frames are nonzero but kills_after_memory_chase stayed zero; verify memory-kill instrumentation and chase conversion.")
         elif kills_after_memory_chase > 0:
             lines.append("- **Interpretation:** Memory-assisted chase is contributing to kills; nonzero kills_after_memory_chase indicates quarry memory is participating in successful same-target chase episodes.")
         target_switches_per_life = g.get("target_switches_per_completed_life")


### PR DESCRIPTION
### Motivation
- Perform a post-merge cleanup and consistency audit after recent predator-prey feature merges, keeping wording consistent without changing simulation mechanics or tuning. 
- Remove duplicated/awkward paragraphs and stale/inaccurate phrasing around sighting semantics, quarry memory, and prey frailty so docs/tests reflect the implemented behavior precisely. 

### Description
- Clarified predator/prey wording in `docs/help_predator_prey.md`, `docs/predator_prey_system_guide.md`, `docs/primordial_guide.md`, and `README.md` to use consistent terminology such as “depth-adjusted usable prey sighting”, “finite-radius omnidirectional sensing”, and explicit constraints on `quarry memory` and `prey frailty`. 
- Refined diagnostic report wording in `tools/predator_collapse_diagnostics.py` to make the memory interpretation text conditional, soften recommendation phrasing ("dominates" → "is common"), and preserve all existing diagnostic semantics. 
- Updated tests in `tests/test_predator_collapse_diagnostics.py` to match revised wording and to assert the changelog formatting expectations. 
- Added a cleanup entry to `CHANGELOG.md` documenting the non-functional doc/diagnostic tidy-up and removed duplicated blank-line artifacts produced by previous merges. 
- No simulation, tuning, or gameplay logic was modified; changes are strictly documentation, diagnostics messaging, and small test-string updates. 

### Testing
- Ran `python -m unittest tests.test_ecology_sensing tests.test_config_authority` and both targeted test modules passed. 
- Ran `python -m unittest tests.test_predator_collapse_diagnostics` but the run failed to import due to a missing `pygame` dependency in this environment (`ModuleNotFoundError: No module named 'pygame'`), so the diagnostics module could not be executed here. 
- Ran `python -m unittest discover tests` which started successfully but full discovery failed in this environment for multiple graphical/renderer-dependent tests for the same `pygame` import reason, so a full test pass could not be validated here. 
- Summary: doc and diagnostic wording changes applied and unit expectations updated; environment-specific `pygame` dependency prevented executing some GUI/diagnostic tests in this CI-like environment, and no behavioral changes were made to the simulation logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1271d43f30832c92198429db03c3bb)