### PR TITLE
feat: add ecology observability summaries to HUD and Inspect Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Primordial are documented in this file.
 
+## [2026-05-24] — fix: keep ecology observability baselines honest and readable
+
+- Fixed observability reset baseline capture so each reset run snapshots baseline traits immediately after spawning population.
+- Replaced hardcoded 30 Hz age/lineage seconds conversion with active mode `simulation_tick_hz` fallback logic.
+- Preserved snapshot compatibility by accepting versions 1, 2, and 3; version 2 loads now rebuild stable lineage metadata and capture a one-time load baseline when missing.
+- Improved Inspect labels for new observability rows (`Age`, `Lin age`, `Lin size`, `Age pct`, `Above avg`, `Below avg`) and tightened HUD/Inspect text fitting/wrapping to avoid clipping.
+
 ## [2026-05-24] — chore: clean up predator prey docs and diagnostics
 
 - Cleaned predator-prey documentation wording for usable depth-adjusted prey sightings, finite-radius omnidirectional sensing, quarry-memory constraints, and prey frailty scope.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1792,3 +1792,5 @@ Guardrails preserved in this pass:
 - Follow-up fix: predator hunt target acquisition now selects the best **usable sensed** prey candidate during scan (nearest unsensed prey no longer blocks farther sensed prey), and depth tracking now begins only after usable target selection.
 
 - Cleanup: clarified quarry-memory diagnostics semantics so `kills_after_memory_chase` counts memory-assisted chase episodes that end in killing the same target, and tightened target-switch counting to exclude first-acquire/same-target reacquisition noise.
+
+- Added HUD/Inspect observability summaries for population age, lineage age, and run-baseline trait-drift direction/distance, including snapshot-compatible lineage first-seen metadata rebuild fallback for older saves.

--- a/docs/predator_prey_system_guide.md
+++ b/docs/predator_prey_system_guide.md
@@ -434,3 +434,5 @@ Predators now choose among final sensed usable prey targets; a nearby prey that 
 Predators now keep short quarry memory (target id, last-known position/depth, last-seen frame) and can briefly pursue last known position when live sensing drops out. Memory pursuit is weaker than live sensing, does not increment usable sighting metrics, and does not bypass normal same-depth contact kill rules.
 
 Quarry-memory diagnostics now distinguish strict target switches from same-target reacquisitions, and `kills_after_memory_chase` reports memory-assisted same-target kills after memory chase episodes.
+
+- HUD/Inspect observability now includes average age, lineage age, and compact evolution drift direction (run-baseline trait-average deltas). These are descriptive observability metrics, not adaptation proof.

--- a/docs/predator_prey_system_guide.md
+++ b/docs/predator_prey_system_guide.md
@@ -436,3 +436,5 @@ Predators now keep short quarry memory (target id, last-known position/depth, la
 Quarry-memory diagnostics now distinguish strict target switches from same-target reacquisitions, and `kills_after_memory_chase` reports memory-assisted same-target kills after memory chase episodes.
 
 - HUD/Inspect observability now includes average age, lineage age, and compact evolution drift direction (run-baseline trait-average deltas). These are descriptive observability metrics, not adaptation proof.
+
+- Snapshot compatibility note: older snapshots missing observability baseline metadata now capture a stable load-time baseline so evolution drift remains descriptive and does not use a moving fallback.

--- a/primordial/rendering/hud.py
+++ b/primordial/rendering/hud.py
@@ -10,9 +10,6 @@ if TYPE_CHECKING:
     from ..simulation.simulation import Simulation
 
 
-TICKS_PER_SECOND = 30.0
-
-
 class HUD:
     """
     Heads-up display for simulation information.
@@ -68,9 +65,10 @@ class HUD:
     def _observability_lines(self, simulation: "Simulation") -> list[str]:
         pop = simulation.get_population_observability_summary()
         evo = simulation.get_evolution_summary()
-        avg_age = pop["average_age_ticks"] / TICKS_PER_SECOND
-        avg_lin = pop["average_lineage_age_ticks"] / TICKS_PER_SECOND
-        old_lin = pop["oldest_lineage_age_ticks"] / TICKS_PER_SECOND
+        tick_hz = simulation.get_simulation_tick_hz()
+        avg_age = pop["average_age_ticks"] / tick_hz
+        avg_lin = pop["average_lineage_age_ticks"] / tick_hz
+        old_lin = pop["oldest_lineage_age_ticks"] / tick_hz
         directions = ", ".join(evo["top_directions"][:3]) if evo["top_directions"] else "stable"
         return [
             f"Age avg {avg_age:.0f}s | Lin {int(pop['active_lineage_count'])} avg {avg_lin:.0f}s old {old_lin:.0f}s",
@@ -223,6 +221,8 @@ class HUD:
         lines.append(f"FPS: {fps:.0f}")
         if debug_lines:
             lines.extend(debug_lines)
+        max_panel_width = max(220, surface.get_width() - 20)
+        lines = self._fit_lines(lines, max_panel_width - self.padding * 2)
 
         food_bar_height = 12
         food_bar_margin = 6
@@ -239,7 +239,7 @@ class HUD:
             bar_row_width = 80 + bar_label_w * 2 + 8
             max_width = max(max_width, bar_row_width)
 
-        panel_width = max_width + self.padding * 2
+        panel_width = min(max_panel_width, max_width + self.padding * 2)
         panel_height = (
             len(lines) * self.line_height
             + (food_bar_height + food_bar_margin if show_food_bar else 0)
@@ -283,6 +283,36 @@ class HUD:
         screen_height = surface.get_height()
         pos = (10, screen_height - panel_height - 10)
         surface.blit(panel, pos)
+
+    def _fit_lines(self, lines: list[str], max_text_width: int) -> list[str]:
+        fitted: list[str] = []
+        for line in lines:
+            if self.font.size(line)[0] <= max_text_width:
+                fitted.append(line)
+                continue
+            words = line.split(" ")
+            if not words:
+                fitted.append("...")
+                continue
+            current = words[0]
+            for word in words[1:]:
+                candidate = f"{current} {word}"
+                if self.font.size(candidate)[0] <= max_text_width:
+                    current = candidate
+                    continue
+                fitted.append(self._truncate(current, max_text_width))
+                current = word
+            fitted.append(self._truncate(current, max_text_width))
+        return fitted
+
+    def _truncate(self, text: str, max_width: int) -> str:
+        if self.font.size(text)[0] <= max_width:
+            return text
+        trimmed = text
+        ellipsis = "..."
+        while trimmed and self.font.size(trimmed + ellipsis)[0] > max_width:
+            trimmed = trimmed[:-1]
+        return (trimmed + ellipsis) if trimmed else ellipsis
 
     def toggle(self) -> None:
         """Toggle HUD visibility."""

--- a/primordial/rendering/hud.py
+++ b/primordial/rendering/hud.py
@@ -10,6 +10,9 @@ if TYPE_CHECKING:
     from ..simulation.simulation import Simulation
 
 
+TICKS_PER_SECOND = 30.0
+
+
 class HUD:
     """
     Heads-up display for simulation information.
@@ -62,6 +65,19 @@ class HUD:
     # Mode-specific line builders
     # ------------------------------------------------------------------
 
+    def _observability_lines(self, simulation: "Simulation") -> list[str]:
+        pop = simulation.get_population_observability_summary()
+        evo = simulation.get_evolution_summary()
+        avg_age = pop["average_age_ticks"] / TICKS_PER_SECOND
+        avg_lin = pop["average_lineage_age_ticks"] / TICKS_PER_SECOND
+        old_lin = pop["oldest_lineage_age_ticks"] / TICKS_PER_SECOND
+        directions = ", ".join(evo["top_directions"][:3]) if evo["top_directions"] else "stable"
+        return [
+            f"Age avg {avg_age:.0f}s | Lin {int(pop['active_lineage_count'])} avg {avg_lin:.0f}s old {old_lin:.0f}s",
+            f"Evo Δ{float(evo['distance']):.3f}: {directions}",
+        ]
+
+
     def _epistasis_lines(self, simulation: "Simulation") -> list[str]:
         summary = simulation.get_epistasis_summary()
         if not summary["enabled"] or simulation.population <= 0:
@@ -98,6 +114,7 @@ class HUD:
             f"Avg lifespan: {avg_ls_str}",
             f"Zone: {dom_zone}",
             f"Food: {simulation.food_count}",
+            *self._observability_lines(simulation),
             *self._epistasis_lines(simulation),
             f"Mode: {simulation.settings.sim_mode}",
             f"Theme: {simulation.settings.visual_theme}",
@@ -149,6 +166,7 @@ class HUD:
             ),
             danger_line,
             trial_line,
+            *self._observability_lines(simulation),
             *self._epistasis_lines(simulation),
             f"Zone: {dom_zone}",
             f"Mode: predator_prey",
@@ -166,6 +184,7 @@ class HUD:
             f"Largest flock: {largest}  Loners: {loners}",
             f"Avg conformity: {avg_conformity:.2f}",
             f"Generation: {simulation.generation}",
+            *self._observability_lines(simulation),
             *self._epistasis_lines(simulation),
             f"Mode: boids",
             f"Theme: {simulation.settings.visual_theme}",
@@ -180,6 +199,7 @@ class HUD:
             f"Generation: {simulation.generation}",
             f"Lineages: {lineage_count}",
             f"Most variable: {most_var}",
+            *self._observability_lines(simulation),
             *self._epistasis_lines(simulation),
             f"Mode: drift",
             f"Theme: {simulation.settings.visual_theme}",

--- a/primordial/rendering/inspect_mode.py
+++ b/primordial/rendering/inspect_mode.py
@@ -339,6 +339,24 @@ def build_creature_card(
 
     card["pos"] = f"({creature.x:.0f}, {creature.y:.0f})"
 
+    try:
+        creature_obs = simulation.get_creature_observability(creature)
+    except Exception:
+        creature_obs = {}
+
+    if creature_obs:
+        card["age_seconds"] = f"{float(creature_obs.get('age_seconds', 0.0)):.1f}s"
+        card["lineage_age"] = f"{float(creature_obs.get('lineage_age_seconds', 0.0)):.1f}s"
+        card["lineage_size"] = str(int(creature_obs.get('lineage_size', 1)))
+        card["species_age_percentile"] = f"{float(creature_obs.get('species_age_percentile', 0.0)):.0f}%"
+        above = creature_obs.get("above_population_traits", ())
+        below = creature_obs.get("below_population_traits", ())
+        if above:
+            card["above_population"] = ", ".join(above)
+        if below:
+            card["below_population"] = ", ".join(below)
+
+
     # ── Genome section ──
     card["section_genome"] = ""
     card["speed"] = f"{creature.genome.speed:.2f}"
@@ -481,6 +499,8 @@ def build_inspect_panel_lines(
                 removable=True,
                 priority=35,
             ),
+            _build_row_pair("age_seconds", card.get("age_seconds", "—"), "lineage_age", card.get("lineage_age", "—"), removable=True, priority=35),
+            _build_row_pair("lineage", card.get("lineage", "—"), "lineage_size", card.get("lineage_size", "—"), removable=True, priority=36),
             InspectPanelLine(kind="section", text="Behavior"),
             _build_row("behavior", _titleize(card.get("behavior", "unknown"))),
         ]
@@ -567,7 +587,10 @@ def build_inspect_panel_lines(
                     priority=90,
                 ),
                 _build_row("eff", card.get("eff", "—"), style="detail", removable=True, priority=90),
+                _build_row("species_age_percentile", card.get("species_age_percentile", "—"), style="detail", removable=True, priority=90),
                 _build_row("pos", card.get("pos", "—"), style="detail", removable=True, priority=95),
+                _build_row("above_population", card.get("above_population", "—"), style="detail", removable=True, priority=96),
+                _build_row("below_population", card.get("below_population", "—"), style="detail", removable=True, priority=96),
             ]
         )
         if "recent_animal_e" in card:

--- a/primordial/rendering/inspect_mode.py
+++ b/primordial/rendering/inspect_mode.py
@@ -206,6 +206,12 @@ _INSPECT_LABELS: dict[str, str] = {
     "likely_goal": "Likely goal",
     "body_plan": "Body plan",
     "key_effect": "Key effect",
+    "age_seconds": "Age",
+    "lineage_age": "Lin age",
+    "lineage_size": "Lin size",
+    "species_age_percentile": "Age pct",
+    "above_population": "Above avg",
+    "below_population": "Below avg",
     "modifier_speed_mult": "Speed",
     "modifier_movement_cost_mult": "Move cost",
     "modifier_metabolic_cost_mult": "Metabolism",
@@ -1036,7 +1042,7 @@ def _render_line(line: InspectPanelLine, fonts, content_width: int) -> dict[str,
     value_font = fonts["body"] if line.style == "body" else fonts["detail"]
     label_text = f"{line.label}:"
     label_surf = label_font.render(label_text, True, _INSPECT_LABEL)
-    if line.key == "tags":
+    if line.key in {"tags", "above_population", "below_population"}:
         wrapped_values = _wrap_comma_separated_text(
             value_font,
             line.value,
@@ -1066,7 +1072,8 @@ def _render_line(line: InspectPanelLine, fonts, content_width: int) -> dict[str,
             "height": height,
         }
 
-    wrapped_values = _wrap_text(value_font, line.value, content_width - 14, max_lines=3)
+    max_lines = 4 if line.key in {"key_effect", "above_population", "below_population"} else 3
+    wrapped_values = _wrap_text(value_font, line.value, content_width - 14, max_lines=max_lines)
     return _render_wrapped_row(label_surf, value_font, wrapped_values, content_width)
 
 

--- a/primordial/simulation/observability.py
+++ b/primordial/simulation/observability.py
@@ -1,0 +1,90 @@
+"""Pure helpers for population and lineage observability summaries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+TRACKED_TRAITS = (
+    "speed",
+    "size",
+    "sense_radius",
+    "aggression",
+    "efficiency",
+    "longevity",
+    "depth_preference",
+    "conformity",
+    "motion_style",
+)
+
+
+@dataclass(frozen=True)
+class LineageObservabilitySummary:
+    active_lineage_count: int
+    average_lineage_age_ticks: float
+    oldest_lineage_age_ticks: int
+
+
+@dataclass(frozen=True)
+class EvolutionSummary:
+    average_age_ticks: float
+    evolution_distance_mean_abs: float
+    top_trait_directions: tuple[str, ...]
+
+
+def average_age_ticks(creatures: Sequence[object]) -> float:
+    if not creatures:
+        return 0.0
+    return sum(float(c.age) for c in creatures) / len(creatures)
+
+
+def average_traits(creatures: Sequence[object], traits: Sequence[str] = TRACKED_TRAITS) -> dict[str, float]:
+    if not creatures:
+        return {trait: 0.0 for trait in traits}
+    totals = {trait: 0.0 for trait in traits}
+    for creature in creatures:
+        for trait in traits:
+            totals[trait] += float(getattr(creature.genome, trait))
+    pop = float(len(creatures))
+    return {trait: value / pop for trait, value in totals.items()}
+
+
+def trait_deltas(current: Mapping[str, float], baseline: Mapping[str, float]) -> dict[str, float]:
+    return {trait: float(current.get(trait, 0.0)) - float(baseline.get(trait, 0.0)) for trait in current.keys()}
+
+
+def evolution_distance_mean_abs(deltas: Mapping[str, float]) -> float:
+    if not deltas:
+        return 0.0
+    return sum(abs(v) for v in deltas.values()) / len(deltas)
+
+
+def top_trait_directions(deltas: Mapping[str, float], *, noise_threshold: float = 0.015, limit: int = 3) -> tuple[str, ...]:
+    filtered = [(k, v) for k, v in deltas.items() if abs(v) >= noise_threshold]
+    filtered.sort(key=lambda item: abs(item[1]), reverse=True)
+    out: list[str] = []
+    for trait, delta in filtered[:limit]:
+        label = trait.replace("_radius", "").replace("_preference", "").replace("_", " ")
+        out.append(f"{label} {delta:+.02f}")
+    return tuple(out)
+
+
+def lineage_summary_for_population(
+    creatures: Sequence[object],
+    *,
+    current_tick: int,
+    lineage_first_seen_ticks: Mapping[int, int],
+) -> LineageObservabilitySummary:
+    if not creatures:
+        return LineageObservabilitySummary(0, 0.0, 0)
+
+    active_lineages = {int(c.lineage_id) for c in creatures}
+    ages: list[int] = []
+    for lineage_id in active_lineages:
+        first_seen = int(lineage_first_seen_ticks.get(lineage_id, current_tick))
+        ages.append(max(0, current_tick - first_seen))
+    return LineageObservabilitySummary(
+        active_lineage_count=len(active_lineages),
+        average_lineage_age_ticks=sum(ages) / len(ages) if ages else 0.0,
+        oldest_lineage_age_ticks=max(ages) if ages else 0,
+    )

--- a/primordial/simulation/persistence.py
+++ b/primordial/simulation/persistence.py
@@ -16,7 +16,7 @@ from .simulation import Simulation
 from .zones import Zone, ZoneManager
 
 
-SAVE_FORMAT_VERSION = 2
+SAVE_FORMAT_VERSION = 3
 _SUPPORTED_SAVE_FORMAT_VERSIONS = {1, SAVE_FORMAT_VERSION}
 SAVE_KIND = "primordial.world_snapshot"
 
@@ -97,6 +97,14 @@ def load_snapshot_payload(
     simulation.total_deaths = int(counters["total_deaths"])
     simulation._frame = int(counters["frame"])
     simulation._next_lineage_id = int(counters["next_lineage_id"])
+    simulation._lineage_first_seen_tick = {
+        int(k): int(v)
+        for k, v in world.get("observability", {}).get("lineage_first_seen_tick", {}).items()
+    }
+    simulation._run_baseline_traits = {
+        str(k): float(v)
+        for k, v in world.get("observability", {}).get("run_baseline_traits", {}).items()
+    }
     simulation.paused = False
     simulation._old_age_lifespans.clear()
     if resolved_settings.sim_mode == "predator_prey":
@@ -133,6 +141,10 @@ def build_snapshot(simulation: Simulation) -> dict[str, Any]:
             "food": _serialize_food_manager(simulation.food_manager),
             "zones": _serialize_zone_manager(simulation.zone_manager),
             "rng_state": _serialize_random_state(random.getstate()),
+            "observability": {
+                "lineage_first_seen_tick": simulation._lineage_first_seen_tick,
+                "run_baseline_traits": simulation._run_baseline_traits,
+            },
             "predator_prey": (
                 simulation.export_predator_prey_runtime_state()
                 if simulation.settings.sim_mode == "predator_prey"

--- a/primordial/simulation/persistence.py
+++ b/primordial/simulation/persistence.py
@@ -17,7 +17,7 @@ from .zones import Zone, ZoneManager
 
 
 SAVE_FORMAT_VERSION = 3
-_SUPPORTED_SAVE_FORMAT_VERSIONS = {1, SAVE_FORMAT_VERSION}
+_SUPPORTED_SAVE_FORMAT_VERSIONS = {1, 2, SAVE_FORMAT_VERSION}
 SAVE_KIND = "primordial.world_snapshot"
 
 _SIMULATION_SETTING_FIELDS = (
@@ -110,6 +110,10 @@ def load_snapshot_payload(
     if resolved_settings.sim_mode == "predator_prey":
         simulation.restore_predator_prey_runtime_state(world.get("predator_prey", {}))
     simulation.rebuild_derived_state()
+    if not simulation._run_baseline_traits:
+        # Older snapshots do not include observability baseline metadata.
+        # Capture load-time population means once so drift is stable and honest.
+        simulation._capture_run_baseline_observability()
 
     random.setstate(_deserialize_random_state(world["rng_state"]))
     return simulation

--- a/primordial/simulation/simulation.py
+++ b/primordial/simulation/simulation.py
@@ -28,6 +28,15 @@ from .phenotype import (
     strategy_bucket_template,
 )
 from .zones import ZoneManager
+from .observability import (
+    TRACKED_TRAITS,
+    average_age_ticks as obs_average_age_ticks,
+    average_traits as obs_average_traits,
+    evolution_distance_mean_abs as obs_evolution_distance_mean_abs,
+    lineage_summary_for_population,
+    top_trait_directions as obs_top_trait_directions,
+    trait_deltas as obs_trait_deltas,
+)
 
 if TYPE_CHECKING:
     from ..settings import Settings
@@ -313,6 +322,8 @@ class Simulation:
 
         # Lineage counter — each new lineage gets a unique integer ID
         self._next_lineage_id: int = 1
+        self._lineage_first_seen_tick: dict[int, int] = {}
+        self._run_baseline_traits: dict[str, float] = {}
 
         # Event queues read by renderer each frame (renderer clears them)
         self.death_events: list[dict] = []
@@ -354,6 +365,7 @@ class Simulation:
         # Initialize population
         if bootstrap_world:
             self._spawn_initial_population()
+        self._capture_run_baseline_observability()
 
     def set_predator_prey_run_logger(self, run_logger: Any) -> None:
         """Attach an optional run logger used by predator-prey stability mode."""
@@ -1147,6 +1159,7 @@ class Simulation:
         """Allocate and return a new unique lineage ID."""
         lid = self._next_lineage_id
         self._next_lineage_id += 1
+        self._lineage_first_seen_tick.setdefault(lid, self._frame)
         return lid
 
     def _spawn_initial_population(self) -> None:
@@ -1321,6 +1334,8 @@ class Simulation:
         self.total_deaths = 0
         self._frame = 0
         self._next_lineage_id = 1
+        self._lineage_first_seen_tick = {}
+        self._run_baseline_traits = {}
         self.death_events.clear()
         self.birth_events.clear()
         self.cosmic_ray_events.clear()
@@ -1420,6 +1435,8 @@ class Simulation:
         self._recent_cross_band_miss_frames.clear()
         self._predation_victims_this_frame.clear()
         self._reset_predator_diagnostics()
+
+        self._rebuild_lineage_first_seen_ticks()
 
         for creature in self.creatures:
             creature.trail = []
@@ -4992,6 +5009,78 @@ class Simulation:
     def get_lineage_count(self) -> int:
         """Return number of distinct lineages currently alive."""
         return len(set(c.lineage_id for c in self.creatures))
+
+    def _capture_run_baseline_observability(self) -> None:
+        self._run_baseline_traits = obs_average_traits(self.creatures, TRACKED_TRAITS)
+
+    def _rebuild_lineage_first_seen_ticks(self) -> None:
+        if not self.creatures:
+            self._lineage_first_seen_tick = {}
+            return
+        rebuilt: dict[int, int] = {}
+        for creature in self.creatures:
+            lineage_id = int(creature.lineage_id)
+            known = self._lineage_first_seen_tick.get(lineage_id)
+            if known is not None:
+                rebuilt[lineage_id] = min(rebuilt.get(lineage_id, known), known)
+                continue
+            # Older snapshots may not persist first-seen lineage metadata.
+            # Conservative fallback: infer a plausible origin from the oldest
+            # living member age in the lineage (current_tick - max_member_age).
+            inferred = max(0, self._frame - int(creature.age))
+            rebuilt[lineage_id] = min(rebuilt.get(lineage_id, inferred), inferred)
+        self._lineage_first_seen_tick = rebuilt
+
+    def get_population_observability_summary(self) -> dict[str, float | int]:
+        lineage = lineage_summary_for_population(
+            self.creatures,
+            current_tick=self._frame,
+            lineage_first_seen_ticks=self._lineage_first_seen_tick,
+        )
+        return {
+            "average_age_ticks": obs_average_age_ticks(self.creatures),
+            "active_lineage_count": lineage.active_lineage_count,
+            "average_lineage_age_ticks": lineage.average_lineage_age_ticks,
+            "oldest_lineage_age_ticks": lineage.oldest_lineage_age_ticks,
+        }
+
+    def get_evolution_summary(self) -> dict[str, object]:
+        current = obs_average_traits(self.creatures, TRACKED_TRAITS)
+        baseline = self._run_baseline_traits or current
+        deltas = obs_trait_deltas(current, baseline)
+        return {
+            "distance": obs_evolution_distance_mean_abs(deltas),
+            "top_directions": obs_top_trait_directions(deltas),
+            "deltas": deltas,
+        }
+
+    def get_creature_observability(self, creature: Creature) -> dict[str, object]:
+        if creature not in self.creatures:
+            return {}
+        pop_traits = obs_average_traits(self.creatures, ("speed", "size", "sense_radius", "aggression", "efficiency", "depth_preference"))
+        lineage_size = sum(1 for c in self.creatures if c.lineage_id == creature.lineage_id)
+        first_seen = self._lineage_first_seen_tick.get(creature.lineage_id, max(0, self._frame - creature.age))
+        species_ages = [c.age for c in self.creatures if c.species == creature.species] or [creature.age]
+        younger_or_equal = sum(1 for age in species_ages if age <= creature.age)
+        percentile = younger_or_equal / len(species_ages)
+
+        deltas = {
+            "speed": creature.genome.speed - pop_traits["speed"],
+            "size": creature.genome.size - pop_traits["size"],
+            "sense": creature.genome.sense_radius - pop_traits["sense_radius"],
+            "aggr": creature.genome.aggression - pop_traits["aggression"],
+        }
+        sorted_deltas = sorted(deltas.items(), key=lambda item: abs(item[1]), reverse=True)
+        above = tuple(f"{name} {delta:+.02f}" for name, delta in sorted_deltas if delta >= 0.05)
+        below = tuple(f"{name} {delta:+.02f}" for name, delta in sorted_deltas if delta <= -0.05)
+        return {
+            "age_seconds": creature.age / 30.0,
+            "lineage_age_seconds": max(0, self._frame - first_seen) / 30.0,
+            "lineage_size": lineage_size,
+            "species_age_percentile": percentile * 100.0,
+            "above_population_traits": above[:3],
+            "below_population_traits": below[:3],
+        }
 
     def get_most_variable_trait(self) -> str:
         """Return trait name with highest variance across population."""

--- a/primordial/simulation/simulation.py
+++ b/primordial/simulation/simulation.py
@@ -1354,6 +1354,7 @@ class Simulation:
             self.settings.zone_strength,
         )
         self._spawn_initial_population()
+        self._capture_run_baseline_observability()
 
     def _generate_predator_prey_seed(self) -> int:
         return random.SystemRandom().randrange(1, 2_147_483_647)
@@ -5013,6 +5014,15 @@ class Simulation:
     def _capture_run_baseline_observability(self) -> None:
         self._run_baseline_traits = obs_average_traits(self.creatures, TRACKED_TRAITS)
 
+    def get_simulation_tick_hz(self) -> float:
+        """Return active simulation tick rate for observability formatting."""
+        configured = self._get_mode_param("simulation_tick_hz", None)
+        if isinstance(configured, (int, float)) and configured > 0:
+            return float(configured)
+        if getattr(self.settings, "target_fps", 0) > 0:
+            return float(self.settings.target_fps)
+        return 30.0
+
     def _rebuild_lineage_first_seen_ticks(self) -> None:
         if not self.creatures:
             self._lineage_first_seen_tick = {}
@@ -5073,9 +5083,10 @@ class Simulation:
         sorted_deltas = sorted(deltas.items(), key=lambda item: abs(item[1]), reverse=True)
         above = tuple(f"{name} {delta:+.02f}" for name, delta in sorted_deltas if delta >= 0.05)
         below = tuple(f"{name} {delta:+.02f}" for name, delta in sorted_deltas if delta <= -0.05)
+        tick_hz = self.get_simulation_tick_hz()
         return {
-            "age_seconds": creature.age / 30.0,
-            "lineage_age_seconds": max(0, self._frame - first_seen) / 30.0,
+            "age_seconds": creature.age / tick_hz,
+            "lineage_age_seconds": max(0, self._frame - first_seen) / tick_hz,
             "lineage_size": lineage_size,
             "species_age_percentile": percentile * 100.0,
             "above_population_traits": above[:3],

--- a/tests/test_inspect_mode.py
+++ b/tests/test_inspect_mode.py
@@ -711,6 +711,12 @@ class TestInspectPanelPresentation(unittest.TestCase):
         self.assertEqual(friendly_inspect_label("vel"), "Moving")
         self.assertEqual(friendly_inspect_label("attention"), "Focus")
         self.assertEqual(friendly_inspect_label("recent_animal_e"), "Recent prey E")
+        self.assertEqual(friendly_inspect_label("age_seconds"), "Age")
+        self.assertEqual(friendly_inspect_label("lineage_age"), "Lin age")
+        self.assertEqual(friendly_inspect_label("lineage_size"), "Lin size")
+        self.assertEqual(friendly_inspect_label("species_age_percentile"), "Age pct")
+        self.assertEqual(friendly_inspect_label("above_population"), "Above avg")
+        self.assertEqual(friendly_inspect_label("below_population"), "Below avg")
 
     def test_compact_layout_omits_details_section(self):
         mode = InspectMode(enabled=True, detail_mode="compact")

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -11,6 +11,8 @@ from primordial.simulation.observability import (
     top_trait_directions,
     trait_deltas,
 )
+from primordial.settings import Settings
+from primordial.simulation.simulation import Simulation
 
 
 def _creature(age: int, lineage_id: int, species: str = "prey", **traits):
@@ -45,3 +47,30 @@ def test_lineage_summary_active_counts_and_ages():
     assert summary.active_lineage_count == 2
     assert summary.oldest_lineage_age_ticks == 80
     assert summary.average_lineage_age_ticks == 50
+
+
+def test_reset_recaptures_run_baseline_observability():
+    settings = Settings()
+    settings.sim_mode = "energy"
+    sim = Simulation(240, 160, settings)
+    assert sim._run_baseline_traits
+    original = dict(sim._run_baseline_traits)
+    sim._run_baseline_traits = {}
+    sim.reset()
+    assert sim._run_baseline_traits
+    assert sim._run_baseline_traits != {}
+    assert set(sim._run_baseline_traits) == set(original)
+
+
+def test_creature_observability_uses_mode_tick_hz():
+    settings = Settings()
+    settings.sim_mode = "drift"
+    settings.mode_params["drift"]["simulation_tick_hz"] = 60
+    sim = Simulation(240, 160, settings)
+    creature = sim.creatures[0]
+    creature.age = 120
+    sim._frame = 240
+    sim._lineage_first_seen_tick[creature.lineage_id] = 60
+    obs = sim.get_creature_observability(creature)
+    assert obs["age_seconds"] == pytest.approx(2.0)
+    assert obs["lineage_age_seconds"] == pytest.approx(3.0)

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+from types import SimpleNamespace
+
+from primordial.simulation.observability import (
+    average_age_ticks,
+    average_traits,
+    evolution_distance_mean_abs,
+    lineage_summary_for_population,
+    top_trait_directions,
+    trait_deltas,
+)
+
+
+def _creature(age: int, lineage_id: int, species: str = "prey", **traits):
+    defaults = dict(speed=0.5, size=0.5, sense_radius=0.5, aggression=0.5, efficiency=0.5, longevity=0.5, depth_preference=0.5, conformity=0.5, motion_style=0.5)
+    defaults.update(traits)
+    return SimpleNamespace(age=age, lineage_id=lineage_id, species=species, genome=SimpleNamespace(**defaults))
+
+
+def test_average_age_ticks():
+    creatures = [_creature(10, 1), _creature(20, 2), _creature(30, 2)]
+    assert average_age_ticks(creatures) == 20.0
+
+
+def test_trait_summary_and_evolution_delta():
+    baseline = {"speed": 0.4, "size": 0.5}
+    current = {"speed": 0.5, "size": 0.4}
+    deltas = trait_deltas(current, baseline)
+    assert deltas["speed"] == pytest.approx(0.1)
+    assert deltas["size"] == pytest.approx(-0.1)
+    assert evolution_distance_mean_abs(deltas) == pytest.approx(0.1)
+
+
+def test_top_trait_direction_filter_sort():
+    deltas = {"speed": 0.06, "sense_radius": 0.03, "aggression": -0.08, "size": 0.01}
+    top = top_trait_directions(deltas, noise_threshold=0.015, limit=2)
+    assert top == ("aggression -0.08", "speed +0.06")
+
+
+def test_lineage_summary_active_counts_and_ages():
+    creatures = [_creature(40, 10), _creature(20, 11), _creature(10, 11)]
+    summary = lineage_summary_for_population(creatures, current_tick=100, lineage_first_seen_ticks={10: 20, 11: 80})
+    assert summary.active_lineage_count == 2
+    assert summary.oldest_lineage_age_ticks == 80
+    assert summary.average_lineage_age_ticks == 50

--- a/tests/test_simulation_persistence.py
+++ b/tests/test_simulation_persistence.py
@@ -159,6 +159,24 @@ class SimulationPersistenceTests(unittest.TestCase):
         self.assertTrue(all(c.recent_animal_energy == 0.0 for c in loaded.creatures))
         self.assertTrue(all(c.satiety_ticks_remaining == 0 for c in loaded.creatures))
 
+    def test_load_snapshot_version_2_without_observability_metadata(self) -> None:
+        settings = self._build_settings("energy")
+        settings.initial_population = 8
+        random.seed(999)
+        simulation = Simulation(320, 180, settings)
+        snapshot = build_snapshot(simulation)
+        snapshot["version"] = 2
+        snapshot["world"].pop("observability", None)
+
+        loaded = load_snapshot_payload(snapshot, settings=self._build_settings("energy"))
+
+        self.assertTrue(loaded.creatures)
+        self.assertTrue(loaded._run_baseline_traits)
+        self.assertEqual(
+            set(loaded._run_baseline_traits.keys()),
+            {"speed", "size", "sense_radius", "aggression", "efficiency", "longevity", "depth_preference", "conformity", "motion_style"},
+        )
+
     def test_load_rebuilds_boids_flock_state_without_persisting_it(self) -> None:
         settings = self._build_settings("boids")
         settings.mode_params["boids"].update({


### PR DESCRIPTION
### Motivation

- Improve runtime legibility of the ecosystem by adding compact, read-only population- and lineage-level observability (age, lineage age, and run-baseline trait drift) without changing any simulation rules or balances.

### Description

- Added a pure helper module `primordial/simulation/observability.py` with functions for averaging ages/traits, computing trait deltas, mean absolute evolution distance, and top trait direction formatting with noise filtering (used as the canonical observability math surface).
- Extended `Simulation` with run-scoped observability state (`_lineage_first_seen_tick`, `_run_baseline_traits`), tracked lineage first-seen ticks on allocation, captured a run baseline at spawn/reset via `_capture_run_baseline_observability()`, and added read-only accessor APIs: `get_population_observability_summary()`, `get_evolution_summary()`, and `get_creature_observability()` (all pure/read-only and safe for renderer consumption).
- Persisted observability metadata into snapshots by bumping `SAVE_FORMAT_VERSION` to `3` and adding `observability` payload (`lineage_first_seen_tick` and `run_baseline_traits`), and implemented a compatibility-safe rebuild fallback in `Simulation._rebuild_lineage_first_seen_ticks()` to reconstruct missing first-seen data for older snapshots.
- Expanded renderer-side UI: HUD now adds compact observability lines (`Age avg ... | Lin ...` and `Evo Δ...: ...`) across modes via `_observability_lines()`, and Inspect Mode now surfaces per-creature context (age in seconds, lineage age, lineage size, species-age percentile, and compact above/below population trait deviations) via `build_creature_card` usage of `get_creature_observability()` while preserving existing phenotype/epistasis displays.
- Added targeted unit tests in `tests/test_observability.py` for averaging, trait-deltas, evolution distance, top-trait filtering/sorting, and lineage-summary behavior, and updated `CHANGELOG.md` and `docs/predator_prey_system_guide.md` to mention the new observability lines.

### Testing

- Ran targeted unit tests `pytest -q tests/test_observability.py tests/test_simulation_persistence.py` and they passed (observability helpers and snapshot roundtrip/compatibility checks succeeded). 
- An attempted broader run including `tests/test_inspect_mode.py` failed to collect due to the test environment missing `pygame` (a collection-time dependency), which is an environment issue and not a failure of the observability logic. 
- Snapshot compatibility validation was exercised by saving/loading a predator-prey snapshot and rebuilding transient observability state, and the load/round-trip comparisons succeeded in the tested cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1279b068b0832cbc99de0610482994)